### PR TITLE
Feature/cvsb 8561

### DIFF
--- a/src/test/java/atf/CVSB_165/AtfSelect_CVSB_678.java
+++ b/src/test/java/atf/CVSB_165/AtfSelect_CVSB_678.java
@@ -3,6 +3,7 @@ package atf.CVSB_165;
 import net.serenitybdd.junit.runners.SerenityRunner;
 import net.thucydides.core.annotations.Steps;
 import net.thucydides.core.annotations.Title;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import steps.ATFDetailsSteps;
@@ -22,7 +23,7 @@ public class AtfSelect_CVSB_678 extends BaseTestClass {
     @Steps
     ATFDetailsSteps atfDetailsSteps;
 
-
+    @Ignore("[CVSB-8561] Removing test to improve overall efficiency of the mobile app Front-end automation test suite.")
     @Title("CVSB-165 - AC2 - Select an ATF from the list in alphabetical order")
     @Test
     public void testAtfListAlphabeticallyOrdered() {

--- a/src/test/java/atf/CVSB_167/AtfSelect_CVSB_1450.java
+++ b/src/test/java/atf/CVSB_167/AtfSelect_CVSB_1450.java
@@ -3,6 +3,7 @@ package atf.CVSB_167;
 import net.serenitybdd.junit.runners.SerenityRunner;
 import net.thucydides.core.annotations.Steps;
 import net.thucydides.core.annotations.Title;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import steps.ATFDetailsSteps;
@@ -22,7 +23,7 @@ public class AtfSelect_CVSB_1450 extends BaseTestClass {
     @Steps
     ATFDetailsSteps atfDetailsSteps;
 
-
+    @Ignore("[CVSB-8561] Removing test to improve overall efficiency of the mobile app Front-end automation test suite.")
     @Title("CVSB-167 - AC4 - VSA is able to confirm the selected ATF")
     @Test
     public void testConfirmSelectedAtf() {

--- a/src/test/java/atf/CVSB_167/AtfSelect_CVSB_1452.java
+++ b/src/test/java/atf/CVSB_167/AtfSelect_CVSB_1452.java
@@ -3,6 +3,7 @@ package atf.CVSB_167;
 import net.serenitybdd.junit.runners.SerenityRunner;
 import net.thucydides.core.annotations.Steps;
 import net.thucydides.core.annotations.Title;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import steps.ATFDetailsSteps;
@@ -26,7 +27,7 @@ public class AtfSelect_CVSB_1452 extends BaseTestClass {
     @Steps
     SiteVisitSteps siteVisitSteps;
 
-
+    @Ignore("[CVSB-8561] Removing test to improve overall efficiency of the mobile app Front-end automation test suite.")
     @Title("CVSB-167 - AC5 - VSA is able to confirm that the selected ATF site is suitable for testing")
     @Test
     public void testConfirmAtfSite() {

--- a/src/test/java/defect/CVSB_139/DefectAdd_CVSB_668.java
+++ b/src/test/java/defect/CVSB_139/DefectAdd_CVSB_668.java
@@ -3,6 +3,7 @@ package defect.CVSB_139;
 import net.serenitybdd.junit.runners.SerenityRunner;
 import net.thucydides.core.annotations.Steps;
 import net.thucydides.core.annotations.Title;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import pages.TestPage;
@@ -28,7 +29,7 @@ public class DefectAdd_CVSB_668 extends BaseTestClass {
     @Steps
     TestTypeSubcategorySteps testTypeSubcategorySteps;
 
-
+    @Ignore("[CVSB-8561] Removing test to improve overall efficiency of the mobile app Front-end automation test suite.")
     @Title("CVSB-139 - AC1 - Add a defect from test type details screen")
     @Test
     public void testTypeAddDefectOption() {

--- a/src/test/java/defect/CVSB_145/DefectRemove_CVSB_661.java
+++ b/src/test/java/defect/CVSB_145/DefectRemove_CVSB_661.java
@@ -3,6 +3,7 @@ package defect.CVSB_145;
 import net.serenitybdd.junit.runners.SerenityRunner;
 import net.thucydides.core.annotations.Steps;
 import net.thucydides.core.annotations.Title;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import pages.TestPage;
@@ -34,7 +35,7 @@ public class DefectRemove_CVSB_661 extends BaseTestClass {
     @Steps
     DefectDetailsSteps defectDetailsSteps;
 
-
+    @Ignore("[CVSB-8561] Removing test to improve overall efficiency of the mobile app Front-end automation test suite.")
     @Title("CVSB-145 - AC1- Remove defect pop up message")
     @Test
     public void testRemoveDefectPopUp() {

--- a/src/test/java/defect/CVSB_2569/DefectRemove_CVSB_2573.java
+++ b/src/test/java/defect/CVSB_2569/DefectRemove_CVSB_2573.java
@@ -3,6 +3,7 @@ package defect.CVSB_2569;
 import net.serenitybdd.junit.runners.SerenityRunner;
 import net.thucydides.core.annotations.Steps;
 import net.thucydides.core.annotations.Title;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import pages.TestPage;
@@ -35,6 +36,7 @@ public class DefectRemove_CVSB_2573 extends BaseTestClass {
     DefectDetailsSteps defectDetailsSteps;
 
 
+    @Ignore("[CVSB-8561] Removing test to improve overall efficiency of the mobile app Front-end automation test suite.")
     @Title("CVSB-2569 - CLONE - AC2 - Confirm removal of defect")
     @Test
     public void testConfirmRemovalOfDefect() {

--- a/src/test/java/sitevisit/CVSB_169/SiteVisitTimeline_2059.java
+++ b/src/test/java/sitevisit/CVSB_169/SiteVisitTimeline_2059.java
@@ -3,6 +3,7 @@ package sitevisit.CVSB_169;
 import net.serenitybdd.junit.runners.SerenityRunner;
 import net.thucydides.core.annotations.Steps;
 import net.thucydides.core.annotations.Title;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import pages.SelectReasonPage;
@@ -50,6 +51,7 @@ public class SiteVisitTimeline_2059 extends BaseTestClass {
     @Steps
     EUVehicleCategorySteps euVehicleCategorySteps;
 
+    @Ignore("[CVSB-8561] Removing test to improve overall efficiency of the mobile app Front-end automation test suite.")
     @Title("CVSB-169 - AC2 - VSA is presented with the Site Visit timeline after submitting test results")
     @Test
     public void testSiteVisitTimelineAfterTestResults() {

--- a/src/test/java/testresults/CVSB_197/SubmitTest_CVSB_3076.java
+++ b/src/test/java/testresults/CVSB_197/SubmitTest_CVSB_3076.java
@@ -3,6 +3,7 @@ package testresults.CVSB_197;
 import net.serenitybdd.junit.runners.SerenityRunner;
 import net.thucydides.core.annotations.Steps;
 import net.thucydides.core.annotations.Title;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import pages.TestPage;
@@ -40,6 +41,7 @@ public class SubmitTest_CVSB_3076 extends BaseTestClass {
     @Steps
     SeatbeltInstallationCheckSteps seatbeltInstallationCheckSteps;
 
+    @Ignore("[CVSB-8561] Removing test to improve overall efficiency of the mobile app Front-end automation test suite.")
     @Title("CVSB-197 - AC A1. VSA is presented with a confirmation to submit test results")
     @Test
     public void testConfirmationToSubmitTestResults() {

--- a/src/test/java/testresults/CVSB_197/SubmitTest_CVSB_3078.java
+++ b/src/test/java/testresults/CVSB_197/SubmitTest_CVSB_3078.java
@@ -3,6 +3,7 @@ package testresults.CVSB_197;
 import net.serenitybdd.junit.runners.SerenityRunner;
 import net.thucydides.core.annotations.Steps;
 import net.thucydides.core.annotations.Title;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import pages.TestPage;
@@ -40,6 +41,7 @@ public class SubmitTest_CVSB_3078 extends BaseTestClass {
     @Steps
     SeatbeltInstallationCheckSteps seatbeltInstallationCheckSteps;
 
+    @Ignore("[CVSB-8561] Removing test to improve overall efficiency of the mobile app Front-end automation test suite.")
     @Title("CVSB-197 - AC A3. VSA confirms the submission of test results and is presented with the loading indicator")
     @Test
     public void testLoadingIndicatorAfterConfirmationToSubmitTestResults() {

--- a/src/test/java/testresults/CVSB_495/ReviewTestSummary_2706.java
+++ b/src/test/java/testresults/CVSB_495/ReviewTestSummary_2706.java
@@ -3,6 +3,7 @@ package testresults.CVSB_495;
 import net.serenitybdd.junit.runners.SerenityRunner;
 import net.thucydides.core.annotations.Steps;
 import net.thucydides.core.annotations.Title;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import pages.TestPage;
@@ -37,6 +38,7 @@ public class ReviewTestSummary_2706 extends BaseTestClass {
     @Steps
     TestTypeDetailsSteps testTypeDetailsSteps;
 
+    @Ignore("[CVSB-8561] Removing test to improve overall efficiency of the mobile app Front-end automation test suite.")
     @Title("CVSB-495 - AC6 - Deleting a required field in the test type result and going back to the test review screen")
     @Test
     public void deleteARequiredFieldFromTestType() {

--- a/src/test/java/testtype/CVSB_176/TestTypeRemove_CVSB_760.java
+++ b/src/test/java/testtype/CVSB_176/TestTypeRemove_CVSB_760.java
@@ -3,6 +3,7 @@ package testtype.CVSB_176;
 import net.serenitybdd.junit.runners.SerenityRunner;
 import net.thucydides.core.annotations.Steps;
 import net.thucydides.core.annotations.Title;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import steps.TestSteps;
@@ -18,7 +19,7 @@ public class TestTypeRemove_CVSB_760 extends BaseTestClass {
     @Steps
     TestTypeCategoryComp testTypeCategoryComp;
 
-
+    @Ignore("[CVSB-8561] Removing test to improve overall efficiency of the mobile app Front-end automation test suite.")
     @Title("CVSB-176 - AC1 Removing a test type")
     @Test
     public void testRemoveTestType() {

--- a/src/test/java/testtype/CVSB_176/TestTypeRemove_CVSB_761.java
+++ b/src/test/java/testtype/CVSB_176/TestTypeRemove_CVSB_761.java
@@ -3,6 +3,7 @@ package testtype.CVSB_176;
 import net.serenitybdd.junit.runners.SerenityRunner;
 import net.thucydides.core.annotations.Steps;
 import net.thucydides.core.annotations.Title;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import steps.TestSteps;
@@ -18,7 +19,7 @@ public class TestTypeRemove_CVSB_761 extends BaseTestClass {
     @Steps
     TestTypeCategoryComp testTypeCategoryComp;
 
-
+    @Ignore("[CVSB-8561] Removing test to improve overall efficiency of the mobile app Front-end automation test suite.")
     @Title("CVSB-176 - AC2 Pressing remove button")
     @Test
     public void testPressRemoveTestTypeButton() {

--- a/src/test/java/testtype/CVSB_176/TestTypeRemove_CVSB_762.java
+++ b/src/test/java/testtype/CVSB_176/TestTypeRemove_CVSB_762.java
@@ -3,6 +3,7 @@ package testtype.CVSB_176;
 import net.serenitybdd.junit.runners.SerenityRunner;
 import net.thucydides.core.annotations.Steps;
 import net.thucydides.core.annotations.Title;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import steps.TestSteps;
@@ -18,7 +19,7 @@ public class TestTypeRemove_CVSB_762 extends BaseTestClass {
     @Steps
     TestTypeCategoryComp testTypeCategoryComp;
 
-
+    @Ignore("[CVSB-8561] Removing test to improve overall efficiency of the mobile app Front-end automation test suite.")
     @Title("CVSB-176 - AC3 Confirming removal")
     @Test
     public void testRemovalConfirmation() {

--- a/src/test/java/testtype/CVSB_178/TestTypeSearch_CVSB_821.java
+++ b/src/test/java/testtype/CVSB_178/TestTypeSearch_CVSB_821.java
@@ -3,6 +3,7 @@ package testtype.CVSB_178;
 import net.serenitybdd.junit.runners.SerenityRunner;
 import net.thucydides.core.annotations.Steps;
 import net.thucydides.core.annotations.Title;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import steps.TestSteps;
@@ -22,7 +23,7 @@ public class TestTypeSearch_CVSB_821 extends BaseTestClass {
     @Steps
     TestTypeCategoryComp testTypeCategoryComp;
 
-
+    @Ignore("[CVSB-8561] Removing test to improve overall efficiency of the mobile app Front-end automation test suite.")
     @Title("CVSB-178 - Select a test type category that does not contain other test type categories")
     @Test
     public void testSelectTestTypeCategoryWithNoSubcategories() {

--- a/src/test/java/testtype/CVSB_194/TestTypeAbandon_CVSB_791.java
+++ b/src/test/java/testtype/CVSB_194/TestTypeAbandon_CVSB_791.java
@@ -3,6 +3,7 @@ package testtype.CVSB_194;
 import net.serenitybdd.junit.runners.SerenityRunner;
 import net.thucydides.core.annotations.Steps;
 import net.thucydides.core.annotations.Title;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import steps.AbandonTestSteps;
@@ -34,6 +35,7 @@ public class TestTypeAbandon_CVSB_791 extends BaseTestClass {
     @Steps
     AbandonedTestSteps abandonedTestSteps;
 
+    @Ignore("[CVSB-8561] Removing test to improve overall efficiency of the mobile app Front-end automation test suite.")
     @Title("CVSB-194 - AC1 Abandon option")
     @Test
     public void testRemoveTestType() {

--- a/src/test/java/testtype/CVSB_203/RecordResult_CVSB_1982.java
+++ b/src/test/java/testtype/CVSB_203/RecordResult_CVSB_1982.java
@@ -3,6 +3,7 @@ package testtype.CVSB_203;
 import net.serenitybdd.junit.runners.SerenityRunner;
 import net.thucydides.core.annotations.Steps;
 import net.thucydides.core.annotations.Title;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import pages.TestPage;
@@ -29,7 +30,7 @@ public class RecordResult_CVSB_1982 extends BaseTestClass {
     @Steps
     TestTypeSubcategorySteps testTypeSubcategorySteps;
 
-
+    @Ignore("[CVSB-8561] Removing test to improve overall efficiency of the mobile app Front-end automation test suite.")
     @Title("CVSB-203 - AC1 - Start a test type (Annual)")
     @Test
     public void testStartTestType() {

--- a/src/test/java/testtype/CVSB_203/RecordResult_CVSB_1993.java
+++ b/src/test/java/testtype/CVSB_203/RecordResult_CVSB_1993.java
@@ -3,6 +3,7 @@ package testtype.CVSB_203;
 import net.serenitybdd.junit.runners.SerenityRunner;
 import net.thucydides.core.annotations.Steps;
 import net.thucydides.core.annotations.Title;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import pages.TestPage;
@@ -41,6 +42,7 @@ public class RecordResult_CVSB_1993 extends BaseTestClass {
     @Steps
     TestTypeSubcategorySteps testTypeSubcategorySteps;
 
+    @Ignore("[CVSB-8561] Removing test to improve overall efficiency of the mobile app Front-end automation test suite.")
     @Title("CVSB-203 - AC8 - Go back to test overview")
     @Test
     public void testGoBackToTestOverview() {

--- a/src/test/java/testtype/CVSB_203/RecordResult_CVSB_1994.java
+++ b/src/test/java/testtype/CVSB_203/RecordResult_CVSB_1994.java
@@ -3,6 +3,7 @@ package testtype.CVSB_203;
 import net.serenitybdd.junit.runners.SerenityRunner;
 import net.thucydides.core.annotations.Steps;
 import net.thucydides.core.annotations.Title;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import pages.TestPage;
@@ -41,6 +42,7 @@ public class RecordResult_CVSB_1994 extends BaseTestClass {
     @Steps
     TestTypeSubcategorySteps testTypeSubcategorySteps;
 
+    @Ignore("[CVSB-8561] Removing test to improve overall efficiency of the mobile app Front-end automation test suite.")
     @Title("CVSB-203 - AC9 - Complete a test type")
     @Test
     public void testCompleteATestType() {

--- a/src/test/java/testtype/CVSB_370/TestTypeAdd_CVSB_765.java
+++ b/src/test/java/testtype/CVSB_370/TestTypeAdd_CVSB_765.java
@@ -3,6 +3,7 @@ package testtype.CVSB_370;
 import net.serenitybdd.junit.runners.SerenityRunner;
 import net.thucydides.core.annotations.Steps;
 import net.thucydides.core.annotations.Title;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import steps.PreparerSteps;
@@ -23,7 +24,7 @@ public class TestTypeAdd_CVSB_765 extends BaseTestClass {
     @Steps
     TestSteps testSteps;
 
-
+    @Ignore("[CVSB-8561] Removing test to improve overall efficiency of the mobile app Front-end automation test suite.")
     @Title("CVSB-370 - AC1 'Add a test type' option")
     @Test
     public void testTestTypeOption() {

--- a/src/test/java/testtype/CVSB_370/TestTypeAdd_CVSB_766.java
+++ b/src/test/java/testtype/CVSB_370/TestTypeAdd_CVSB_766.java
@@ -3,6 +3,7 @@ package testtype.CVSB_370;
 import net.serenitybdd.junit.runners.SerenityRunner;
 import net.thucydides.core.annotations.Steps;
 import net.thucydides.core.annotations.Title;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import steps.TestSteps;
@@ -23,7 +24,7 @@ public class TestTypeAdd_CVSB_766 extends BaseTestClass {
     @Steps
     TestTypeCategoryComp testTypeCategoryComp;
 
-
+    @Ignore("[CVSB-8561] Removing test to improve overall efficiency of the mobile app Front-end automation test suite.")
     @Title("CVSB-370 - AC2 Test types list")
     @Test
     public void testTestTypeList() {

--- a/src/test/java/testtype/CVSB_370/TestTypeAdd_CVSB_768.java
+++ b/src/test/java/testtype/CVSB_370/TestTypeAdd_CVSB_768.java
@@ -3,6 +3,7 @@ package testtype.CVSB_370;
 import net.serenitybdd.junit.runners.SerenityRunner;
 import net.thucydides.core.annotations.Steps;
 import net.thucydides.core.annotations.Title;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import steps.TestSteps;
@@ -26,6 +27,7 @@ public class TestTypeAdd_CVSB_768 extends BaseTestClass {
     @Steps
     TestTypeCategoryComp testTypeCategoryComp;
 
+    @Ignore("[CVSB-8561] Removing test to improve overall efficiency of the mobile app Front-end automation test suite.")
     @Title("CVSB-370 - Add a test type from the test types list")
     @Test
     public void testAddTestTypeFromList() {

--- a/src/test/java/testtype/CVSB_695/OdometerReading_CVSB_1176.java
+++ b/src/test/java/testtype/CVSB_695/OdometerReading_CVSB_1176.java
@@ -3,6 +3,7 @@ package testtype.CVSB_695;
 import net.serenitybdd.junit.runners.SerenityRunner;
 import net.thucydides.core.annotations.Steps;
 import net.thucydides.core.annotations.Title;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import steps.OdometerReadingSteps;
@@ -22,6 +23,7 @@ public class OdometerReading_CVSB_1176 extends BaseTestClass {
     @Steps
     OdometerReadingSteps odometerReadingSteps;
 
+    @Ignore("[CVSB-8561] Removing test to improve overall efficiency of the mobile app Front-end automation test suite.")
     @Title("CVSB-695 - AC4 - Record odometer reading value")
     @Test
     public void testRecordOdometerReadingValue() {

--- a/src/test/java/testtype/CVSB_756/CaptureTestInformation_CVSB_1570.java
+++ b/src/test/java/testtype/CVSB_756/CaptureTestInformation_CVSB_1570.java
@@ -3,6 +3,7 @@ package testtype.CVSB_756;
 import net.serenitybdd.junit.runners.SerenityRunner;
 import net.thucydides.core.annotations.Steps;
 import net.thucydides.core.annotations.Title;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import steps.TestHistorySteps;
@@ -26,7 +27,7 @@ public class CaptureTestInformation_CVSB_1570 extends BaseTestClass {
     @Steps
     TestHistorySteps testHistorySteps;
 
-
+    @Ignore("[CVSB-8561] Removing test to improve overall efficiency of the mobile app Front-end automation test suite.")
     @Title("CVSB-756 - AC6 - Go back to vehicle details")
     @Test
     public void testGoBackToVehicleDetails() {

--- a/src/test/java/testtype/CVSB_902/LECTestType_2028.java
+++ b/src/test/java/testtype/CVSB_902/LECTestType_2028.java
@@ -3,6 +3,7 @@ package testtype.CVSB_902;
 import net.serenitybdd.junit.runners.SerenityRunner;
 import net.thucydides.core.annotations.Steps;
 import net.thucydides.core.annotations.Title;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import pages.TestPage;
@@ -27,6 +28,7 @@ public class LECTestType_2028 extends BaseTestClass {
     @Steps
     TestTypeDetailsSteps testTypeDetailsSteps;
 
+    @Ignore("[CVSB-8561] Removing test to improve overall efficiency of the mobile app Front-end automation test suite.")
     @Title("CVSB-902 - AC5 - Enter value for certificate number")
     @Test
     public void enterCertificateNumberValue() {

--- a/src/test/java/testtype/CVSB_983/EditCompletedTestType_2019.java
+++ b/src/test/java/testtype/CVSB_983/EditCompletedTestType_2019.java
@@ -3,6 +3,7 @@ package testtype.CVSB_983;
 import net.serenitybdd.junit.runners.SerenityRunner;
 import net.thucydides.core.annotations.Steps;
 import net.thucydides.core.annotations.Title;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import pages.TestPage;
@@ -27,6 +28,7 @@ public class EditCompletedTestType_2019 extends BaseTestClass {
     @Steps
     SeatbeltInstallationCheckSteps seatbeltInstallationCheckSteps;
 
+    @Ignore("[CVSB-8561] Removing test to improve overall efficiency of the mobile app Front-end automation test suite.")
     @Title("CVSB-983 - AC1 - VSA saves details within the test type and is able to see that the details are editable")
     @Test
     public void testSavedDetailsAreEditable() {

--- a/src/test/java/vehicle/CVSB_183/VehicleSearch_CVSB_1053.java
+++ b/src/test/java/vehicle/CVSB_183/VehicleSearch_CVSB_1053.java
@@ -3,6 +3,7 @@ package vehicle.CVSB_183;
 import net.serenitybdd.junit.runners.SerenityRunner;
 import net.thucydides.core.annotations.Steps;
 import net.thucydides.core.annotations.Title;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import steps.IdentifyVehicleSteps;
@@ -26,7 +27,7 @@ public class VehicleSearch_CVSB_1053 extends BaseTestClass {
     @Steps
     VehicleDetailsSteps vehicleDetailsSteps;
 
-
+    @Ignore("[CVSB-8561] Removing test to improve overall efficiency of the mobile app Front-end automation test suite.")
     @Title("CVSB-183 - AC3.1 Vehicle found in system")
     @Test
     public void testVehicleFoundInSystem() {

--- a/src/test/java/vehicle/CVSB_183/VehicleSearch_CVSB_1155.java
+++ b/src/test/java/vehicle/CVSB_183/VehicleSearch_CVSB_1155.java
@@ -3,6 +3,7 @@ package vehicle.CVSB_183;
 import net.serenitybdd.junit.runners.SerenityRunner;
 import net.thucydides.core.annotations.Steps;
 import net.thucydides.core.annotations.Title;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import steps.IdentifyVehicleSteps;
@@ -26,7 +27,7 @@ public class VehicleSearch_CVSB_1155 extends BaseTestClass {
     @Steps
     VehicleDetailsSteps vehicleDetailsSteps;
 
-
+    @Ignore("[CVSB-8561] Removing test to improve overall efficiency of the mobile app Front-end automation test suite.")
     @Title("CVSB-183 - AC2 Search for vehicle using registration number")
     @Test
     public void testSearchUsingRegistrationNumber() {

--- a/src/test/java/vehicle/CVSB_184/Search_CVSB_1896.java
+++ b/src/test/java/vehicle/CVSB_184/Search_CVSB_1896.java
@@ -3,6 +3,7 @@ package vehicle.CVSB_184;
 import net.serenitybdd.junit.runners.SerenityRunner;
 import net.thucydides.core.annotations.Steps;
 import net.thucydides.core.annotations.Title;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import steps.IdentifyVehicleSteps;
@@ -22,6 +23,7 @@ public class Search_CVSB_1896 extends BaseTestClass {
     @Steps
     VehicleDetailsSteps vehicleDetailsSteps;
 
+    @Ignore("[CVSB-8561] Removing test to improve overall efficiency of the mobile app Front-end automation test suite.")
     @Title("CVSB-184 - AC1 - Search by registration number does return the correct vehicle")
     @Test
     public void testSearchByLastDigitsVin() {

--- a/src/test/java/vehicle/CVSB_185/VehicleDetails_CVSB_1066.java
+++ b/src/test/java/vehicle/CVSB_185/VehicleDetails_CVSB_1066.java
@@ -3,6 +3,7 @@ package vehicle.CVSB_185;
 import net.serenitybdd.junit.runners.SerenityRunner;
 import net.thucydides.core.annotations.Steps;
 import net.thucydides.core.annotations.Title;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import steps.IdentifyVehicleSteps;
@@ -18,7 +19,7 @@ public class VehicleDetails_CVSB_1066 extends BaseTestClass {
     @Steps
     IdentifyVehicleSteps identifyVehicleSteps;
 
-
+    @Ignore("[CVSB-8561] Removing test to improve overall efficiency of the mobile app Front-end automation test suite.")
     @Title("CVSB-185 - AC1 - VSA searches by registration number")
     @Test
     public void testSearchByRegistrationNumber() {

--- a/src/test/java/vehicle/CVSB_185/VehicleDetails_CVSB_1070.java
+++ b/src/test/java/vehicle/CVSB_185/VehicleDetails_CVSB_1070.java
@@ -3,6 +3,7 @@ package vehicle.CVSB_185;
 import net.serenitybdd.junit.runners.SerenityRunner;
 import net.thucydides.core.annotations.Steps;
 import net.thucydides.core.annotations.Title;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import steps.IdentifyVehicleSteps;
@@ -23,6 +24,7 @@ public class VehicleDetails_CVSB_1070 extends BaseTestClass {
     VehicleDetailsSteps vehicleDetailsSteps;
 
 
+    @Ignore("[CVSB-8561] Removing test to improve overall efficiency of the mobile app Front-end automation test suite.")
     @Title("CVSB-185 - AC1 - No search results")
     @Test
     public void testNoSearchResults() {

--- a/src/test/java/vehicle/CVSB_317/TestCreate_CVSB_784.java
+++ b/src/test/java/vehicle/CVSB_317/TestCreate_CVSB_784.java
@@ -3,6 +3,7 @@ package vehicle.CVSB_317;
 import net.serenitybdd.junit.runners.SerenityRunner;
 import net.thucydides.core.annotations.Steps;
 import net.thucydides.core.annotations.Title;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import steps.*;
@@ -26,6 +27,7 @@ public class TestCreate_CVSB_784 extends BaseTestClass {
     @Steps
     PreparerSteps preparerSteps;
 
+    @Ignore("[CVSB-8561] Removing test to improve overall efficiency of the mobile app Front-end automation test suite.")
     @Title("CVSB-317 - AC1 - Create a test")
     @Test()
     public void createATest() {

--- a/src/test/java/vehicle/CVSB_438/Preparer_4795.java
+++ b/src/test/java/vehicle/CVSB_438/Preparer_4795.java
@@ -3,6 +3,7 @@ package vehicle.CVSB_438;
 import net.serenitybdd.junit.runners.SerenityRunner;
 import net.thucydides.core.annotations.Steps;
 import net.thucydides.core.annotations.Title;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import steps.PreparerSteps;
@@ -17,6 +18,7 @@ public class Preparer_4795 extends BaseTestClass {
     @Steps
     PreparerSteps preparerSteps;
 
+    @Ignore("[CVSB-8561] Removing test to improve overall efficiency of the mobile app Front-end automation test suite.")
     @Title("CVSB_438 - AC 1 VSA searches for preparer ID")
     @Test
     public void searchPreparer() {

--- a/src/test/java/vehicle/CVSB_438/Preparer_4796.java
+++ b/src/test/java/vehicle/CVSB_438/Preparer_4796.java
@@ -3,6 +3,7 @@ package vehicle.CVSB_438;
 import net.serenitybdd.junit.runners.SerenityRunner;
 import net.thucydides.core.annotations.Steps;
 import net.thucydides.core.annotations.Title;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import steps.PreparerSteps;
@@ -17,6 +18,7 @@ public class Preparer_4796 extends BaseTestClass {
     @Steps
     PreparerSteps preparerSteps;
 
+    @Ignore("[CVSB-8561] Removing test to improve overall efficiency of the mobile app Front-end automation test suite.")
     @Title("CVSB_438 - AC 2 VSA starts test after adding preparer ID")
     @Test
     public void searchPreparer() {

--- a/src/test/java/vehicle/CVSB_438/Preparer_4797.java
+++ b/src/test/java/vehicle/CVSB_438/Preparer_4797.java
@@ -3,6 +3,7 @@ package vehicle.CVSB_438;
 import net.serenitybdd.junit.runners.SerenityRunner;
 import net.thucydides.core.annotations.Steps;
 import net.thucydides.core.annotations.Title;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import steps.PreparerSteps;
@@ -21,6 +22,7 @@ public class Preparer_4797 extends BaseTestClass {
     @Steps
     TestSteps testSteps;
 
+    @Ignore("[CVSB-8561] Removing test to improve overall efficiency of the mobile app Front-end automation test suite.")
     @Title("CVSB_438 - AC 3 Select preparer and confirm")
     @Test
     public void searchPreparer() {


### PR DESCRIPTION
Removal of tests that don't add much to the automation test run, e.g. "searching for a vehicle" - when this is done multiple times in other tests.

This should speed up the existing test execution time significantly (due to less tests).